### PR TITLE
Switch the order of meta and canonical in the template

### DIFF
--- a/static/templates/partials/iframely-link-title.tpl
+++ b/static/templates/partials/iframely-link-title.tpl
@@ -1,6 +1,6 @@
 <div class="iframely-link">
     <div>
-        <a href="{embed.canonical.meta}" target="_blank" rel="nofollow">
+        <a href="{embed.meta.canonical}" target="_blank" rel="nofollow">
 
             <!-- IF embed.links.icon.length -->
             <!-- BEGIN embed.links.icon -->


### PR DESCRIPTION
The ordering of meta and canonical was swapped, causing links to become blank. Swapping them back (to `meta.canonical`) should fix that :)
