### PR TITLE
Only by itself

### DIFF
--- a/library.js
+++ b/library.js
@@ -21,7 +21,7 @@ var iframely = {
 	cache: LRU({
 		maxAge: 1000*60*60*24	// one day
 	}),
-	htmlRegex: /<a.+?href="(.+?)".*?>(.*?)<\/a>/g
+	htmlRegex: /(?:<p>|^)<a.+?href="(.+?)".*?>(.*?)<\/a>(?:<br\/?>|<\/p>)/g
 };
 var app;
 

--- a/library.js
+++ b/library.js
@@ -21,7 +21,7 @@ var iframely = {
 	cache: LRU({
 		maxAge: 1000*60*60*24	// one day
 	}),
-	htmlRegex: /(?:<p>|^)<a.+?href="(.+?)".*?>(.*?)<\/a>(?:<br\/?>|<\/p>)/g
+	htmlRegex: /(?:<p>|^)<a.+?href="(.+?)".*?>(.*?)<\/a>(?:<br\/?>|<\/p>)/gm
 };
 var app;
 


### PR DESCRIPTION
This change prevents links put in the middle of a sentence from being converted, which surprises users. Links must be by themselves on a line to be converted.
