### PR TITLE
Wrap image-only embeds in a link.

### DIFF
--- a/library.js
+++ b/library.js
@@ -167,6 +167,9 @@ iframely.replace = function(raw, options, callback) {
 							return;
 						}
 					}
+					if (/^<img[^>]+>$/.exec(embedHtml)) {
+						embedHtml = '<a href="' + validator.escape(url) + '">' + embedHtml + '</a>';
+					}
 
 					// Format meta info.
 					var meta = [];


### PR DESCRIPTION
Examples:

```
https://goo.gl/photos/PaVEUvB18Kx6HFHAA
http://xkcd.com/1223/
```