### PR TITLE
Added noreferrer and noopener values to rel attributes

### DIFF
--- a/static/templates/partials/iframely-link-title.tpl
+++ b/static/templates/partials/iframely-link-title.tpl
@@ -1,6 +1,6 @@
 <div class="iframely-link">
     <div>
-        <a href="{url}" target="_blank" rel="nofollow">
+        <a href="{url}" target="_blank" rel="nofollow noreferrer noopener">
 
             <!-- IF icon -->
             <img src="{icon}" class="thumb pull-left not-responsive" />

--- a/static/templates/partials/iframely-widget-card.tpl
+++ b/static/templates/partials/iframely-widget-card.tpl
@@ -10,7 +10,7 @@
 
             <!-- IF title -->
             <h4 class="media-heading">
-                <a href="{url}" target="_blank" rel="nofollow" class="one-line">
+                <a href="{url}" target="_blank" rel="nofollow noreferrer noopener" class="one-line">
                     <!-- IF favicon -->
                     <img src="{favicon}" class="thumb pull-left not-responsive" />
                     <!-- ENDIF favicon -->
@@ -21,7 +21,7 @@
 
             <!-- IF image -->
             <div class="media">
-                <a href="{url}" target="_blank" rel="nofollow">
+                <a href="{url}" target="_blank" rel="nofollow noreferrer noopener">
                     <img src="{image}" alt="{title}" />
                 </a>
             </div>

--- a/static/templates/partials/iframely-widget-wrapper.tpl
+++ b/static/templates/partials/iframely-widget-wrapper.tpl
@@ -2,7 +2,7 @@
 
 	<!-- IF show_title -->
 	<div>
-		<a href="{embed.meta.canonical}" target="_blank" rel="nofollow">
+		<a href="{embed.meta.canonical}" target="_blank" rel="nofollow noreferrer noopener">
 
 			<!-- IF favicon -->
 			<img src="{favicon}" class="thumb pull-left not-responsive" />
@@ -16,7 +16,7 @@
 	<!-- IF widget_html -->
 		<div class="iframely-container">
 			<!-- IF embedIsImg -->
-				<a href="{url}" target="_blank" rel="nofollow">
+				<a href="{url}" target="_blank" rel="nofollow noreferrer noopener">
 					{widget_html}
 				</a>
 			<!-- ELSE -->
@@ -32,7 +32,7 @@
 						}
 					</script>
 					<div data-html="{embedHtmlEscaped}">
-						[<a href="{embed.meta.canonical}" target="_blank">{domain}</a>:
+						[<a href="{embed.meta.canonical}" target="_blank" rel="nofollow noreferrer noopener">{domain}</a>:
 						<!-- IF title -->
 						{title},
 						<!-- ENDIF title -->


### PR DESCRIPTION
Received vulnerability report allowing malicious users to change the location of the page (among other things) of the opening tab if `target="_blank"` is used. Setting `noopener` (and `noreferrer` for older browsers) fixes this unintentional leak.