### PR TITLE
added parse limits to iframely parsing with a default of 3

### DIFF
--- a/library.js
+++ b/library.js
@@ -36,6 +36,7 @@ iframely.init = function(params, callback) {
 	meta.settings.get('iframely', function(err, config) {
 
 		config.blacklist = (config.blacklist && config.blacklist.split(',')) || [];
+		config.parseLimit = parseInt(config.parseLimit, 10) || 3;
 
 		iframely.config = config;
 
@@ -45,7 +46,7 @@ iframely.init = function(params, callback) {
 			cacheMaxAgeDays = DEFAULT_CACHE_MAX_AGE_DAYS;
 		}
 
-		iframely.cache= LRU({
+		iframely.cache = LRU({
 			maxAge: cacheMaxAgeDays * ONE_DAY_MS
 		});
 
@@ -131,6 +132,10 @@ iframely.replace = function(raw, options, callback) {
 
 				// Eliminate duplicates and internal links
 				if (!(uri in urlsDict) && !isInternalLink(target)) {
+					if (Object.keys(urlsDict).length >= iframely.config.parseLimit) {
+						break;
+					}
+
 					urlsDict[uri] = true;
 					urls.push({
 						match: match[0],

--- a/static/templates/admin/plugins/iframely.tpl
+++ b/static/templates/admin/plugins/iframely.tpl
@@ -22,6 +22,16 @@
 	</div>
 
 	<div class="row">
+		<div class="col-sm-2 col-xs-12 settings-header">Limits</div>
+		<div class="col-sm-10 col-xs-12">
+			<div class="form-group">
+				<label for="parseLimit">Maximum number of links to parse (per post):</label>
+				<input type="number" id="parseLimit" name="parseLimit" title="Parsing Limit (per post)" class="form-control input-lg" placeholder="3" />
+			</div>
+		</div>
+	</div>
+
+	<div class="row">
 		<div class="col-sm-2 col-xs-12 settings-header">Disable parsing on negative votes</div>
 		<div class="col-sm-10 col-xs-12">
 			<div class="form-group">


### PR DESCRIPTION
It is possible to cause a NodeBB to lock up due to CPU resource exhaustion if you pass in a raw post with hundreds (maybe thousands) of links.

This change limits it to a default of 3, with ACP adjustable value.