### PR TITLE
fix: regex to fix over-capture, work better with quill

### DIFF
--- a/library.js
+++ b/library.js
@@ -20,7 +20,7 @@ var DEFAULT_CACHE_MAX_AGE_DAYS = 1;
 var iframely = {
 	config: undefined,
 	apiBase: 'http://iframe.ly/api/iframely?origin=nodebb&align=left',
-	htmlRegex: /(?:<p.*?>|^)<a.+?href="(.+?)".*?>(.*?)<\/a>(?:<br\s*\/?>|<\/p>)/gm
+	htmlRegex: /(?:<p[^>]*>|<br\s*\/?>|^)<a.+?href="(.+?)".*?>(.*?)<\/a>(?:<br\s*\/?>|<\/p>)?/gm
 };
 var app;
 


### PR DESCRIPTION
Fixes issues with overly greedy regex, also works better with Quill

----

Hi @iparamonau @nleush -- I've updated the regex to fix the following 3 issues:

1. Quill uses `<br /><br />` to denote new paragraphs. I've updated the regex to add `<br />` as a possible capture target at the start of the regex
1. The existing `<p.*?>` capture target looks acceptable, becomes unnecessarily greedy when additional characters are added. e.g. `<p.*?><` matches `<p>text that should not be matched<a href="url"><` due to the trailing `><` at the end of the match
1. The ending capture group is greedy, and matches the rest of the line. This was not an issue with composer-default but because quill uses line breaks, there might actually be multiple matches on the same line.