### PR TITLE
fix: allow match if anchor href or text has trailing slash but other does not

### DIFF
--- a/library.js
+++ b/library.js
@@ -107,6 +107,13 @@ iframely.replace = function(raw, options, callback) {
 
 		// Isolate matches
 		while(match = iframely.htmlRegex.exec(raw)) {
+			// Eliminate trailing slashes for comparison purposes
+			[1, 2].forEach(key => {
+				if (match[key].endsWith('/')) {
+					match[key] = match[key].slice(0, -1);
+				}
+			});
+
 			// Only match if it is a naked link (no anchor text)
 			var target;
 			try {


### PR DESCRIPTION
This fixes an odd issue where if the anchor href or text has a trailing slash but the other value does not (which could happen if the url was normalized somehow by the composer), then iframely would not consider it a match and would not transform it.